### PR TITLE
Adding sort by different paraments respecting the specified order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.txt') as file:
     long_description = file.read()
 
 
-setup(name='PyDoof', version='1.0.5', author='JoeZ99',
+setup(name='PyDoof', version='1.0.6', author='JoeZ99',
       author_email='jzarate@gmail.com',
       description="Doofinder's search & management API client",
       url='https://github.com/doofinder/pydoof',


### PR DESCRIPTION
I needed to make a doofinder query ordering by two different parameters but I could just specify them as dict keys so the order wasn't respected.

With this approach you can set the exact order of the filters you need to apply.

I hope you like it! ;)
