### PR TITLE
Bugfix/fix boolean

### DIFF
--- a/pydoof/helpers.py
+++ b/pydoof/helpers.py
@@ -56,6 +56,8 @@ def _parse_param(param: str, value: Any):
         query_params.update(
             _dicts_appends(params)
         )
+    elif isinstance(value, bool):
+        query_params[param] = str(value).lower()
     elif value is not None:
         query_params[param] = value
 

--- a/pydoof/search_api/search.py
+++ b/pydoof/search_api/search.py
@@ -77,7 +77,6 @@ def query(hashid: str, query: str = '', auto_filters: bool = None, custom_result
             Default: None.
     """
     query_params = parse_query_params({
-        'hashid': hashid,
         'query': query,
         'auto_filters': auto_filters,
         'custom_results': custom_results,

--- a/tests/search_api/test_search.py
+++ b/tests/search_api/test_search.py
@@ -1,9 +1,6 @@
 from unittest import mock
 import unittest
 
-from requests.sessions import session
-from pydoof.search_api.api_client import SearchAPIClient
-
 from pydoof.search_api.search import query, suggest
 
 from pydoof.search_api.search import QueryNames, SearchFilterExecution
@@ -19,7 +16,7 @@ class TestSearch(unittest.TestCase):
 
         APIClientMock.return_value.get.assert_called_once_with(
             f'/6/{hashid}/_search',
-            query_params={'hashid': hashid, 'query': 'QUERY'}
+            query_params={'query': 'QUERY'}
         )
 
     @mock.patch('pydoof.search_api.search.SearchAPIClient')
@@ -59,7 +56,7 @@ class TestSearch(unittest.TestCase):
                           'query_name': 'match_and',
                           'sort[0][brand]': 'asc',
                           'page': page, 'rpp': rpp,
-                          'stats': True,
+                          'stats': 'true',
                           'filter_execution': 'or',
                           'skip_top_facet[]': skip_to_facet,
                           'skip_auto_filters[]': skip_auto_filters}
@@ -77,5 +74,5 @@ class TestSearch(unittest.TestCase):
             f'/6/{hashid}/_suggest',
             query_params={'query': 'QUERY',
                           'indices[]': indices,
-                          'stats': False}
+                          'stats': 'false'}
         )

--- a/tests/search_api/test_search.py
+++ b/tests/search_api/test_search.py
@@ -42,7 +42,7 @@ class TestSearch(unittest.TestCase):
 
         APIClientMock.return_value.get.assert_called_once_with(
             f'/6/{hashid}/_search',
-            query_params={'hashid': hashid, 'query': 'QUERY',
+            query_params={'query': 'QUERY',
                           'filter[brand]': 'MyBrand',
                           'exclude[color][]': ['blue', 'red'],
                           'exclude[size]': 'M',

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -47,6 +47,18 @@ class TestParseQueryParams(unittest.TestCase):
             {'iterable[]': ['a', 'b', 'c', 'd'], 'string': 'String'}
         )
 
+    def test_can_parse_booleans(self):
+        """Boolean values can be parsed to lower case string."""
+        result = parse_query_params({
+            'stats': False,
+            'another_param': True
+        })
+
+        self.assertEqual(
+            result,
+            {'stats': 'false', 'another_param': 'true'}
+        )
+
     def test_discards_none_values(self):
         """Parameters with 'None' values are discarded."""
         result = parse_query_params({
@@ -55,4 +67,4 @@ class TestParseQueryParams(unittest.TestCase):
             'bar': False
         })
 
-        self.assertEqual(result, {'foo': True, 'bar': False})
+        self.assertEqual(result, {'foo': 'true', 'bar': 'false'})


### PR DESCRIPTION
* It was sent like a Title case string but now it requires lower case. iex.: 'True' => 'true'.
* Removed `hasid` on `search_api.query` `query_params` because is not necessary.
* Removed unnecessary imports on test.