### PR TITLE
Fix bulk_delete

### DIFF
--- a/pydoof/management_api/items.py
+++ b/pydoof/management_api/items.py
@@ -146,6 +146,6 @@ def bulk_delete(hashid, name, items, temp=False, **opts):
     api_client = ManagementAPIClient(**opts)
     return api_client.request(
         method="DELETE", 
-        url=_get_bulk_url(hashid, name), 
+        url=_get_bulk_url(hashid, name, temp), 
         json=items,
     )

--- a/pydoof/management_api/items.py
+++ b/pydoof/management_api/items.py
@@ -144,7 +144,8 @@ def bulk_update(hashid, name, items, temp=False, **opts):
 
 def bulk_delete(hashid, name, items, temp=False, **opts):
     api_client = ManagementAPIClient(**opts)
-    return api_client.delete(
-        _get_bulk_url(hashid, name, temp),
-        items
+    return api_client.request(
+        method="DELETE", 
+        url=_get_bulk_url(hashid, name), 
+        json=items,
     )


### PR DESCRIPTION
Items were passed as query params, and should be passed in the body as json

Reference:
https://docs.doofinder.com/api/management/v2/index.html#operation/items_bulk_delete